### PR TITLE
Small fix for querying service

### DIFF
--- a/02_service_hello_world/query.py
+++ b/02_service_hello_world/query.py
@@ -1,3 +1,4 @@
+import os
 import requests
 
 # The "anyscale service deploy" script outputs a line that looks like
@@ -9,7 +10,7 @@ token = <SERVICE_TOKEN>  # Fill this in.
 base_url = <BASE_URL>  # Fill this in.
 
 resp = requests.get(
-    f"{base_url}/hello",
+    os.path.join(base_url, "hello"),
     params={"name": "Theodore"},
     headers={"Authorization": f"Bearer {token}"})
 


### PR DESCRIPTION
When you deploy a service, it prints something like

```
(anyscale +5m10.4s) curl -H "Authorization: Bearer xxxxxxxxxxxxxxxxxxxx" https://....anyscaleuserdata.com/
```

When you copy and paste the base URL, it's natural to copy it along with the trailing `/`, but if you do that, then you'd previously get a URL like `https://....anyscaleuserdata.com//hello` which wouldn't work.

This fixes that issue.