### PR TITLE
Use L4 instead of A10G for LLM serving example

### DIFF
--- a/03_deploy_llama_3_8b/serve_llama_3_8b.py
+++ b/03_deploy_llama_3_8b/serve_llama_3_8b.py
@@ -7,7 +7,7 @@ llm_config = LLMConfig(
         model_id="my-llama-3-8B",
         model_source="meta-llama/Meta-Llama-3-8B-Instruct",
     ),
-    accelerator_type="A10G",
+    accelerator_type="L4",
     deployment_config=dict(
         autoscaling_config=dict(
             min_replicas=1, max_replicas=2,


### PR DESCRIPTION
Tested that this works on both AWS and GCP (whereas A10Gs only worked on AWS).

The goal is to make examples as cloud agnostic as possible.