### PR TITLE
Add tutorial 4 Llama 3.1 70b

### DIFF
--- a/04_deploy_llama_3_70b/Dockerfile
+++ b/04_deploy_llama_3_70b/Dockerfile
@@ -1,0 +1,8 @@
+FROM anyscale/ray:2.49.0-slim-py312-cu128
+
+# C compiler for Triton’s runtime build step (vLLM V1 engine)
+# https://github.com/vllm-project/vllm/issues/2997
+RUN sudo apt-get update && \
+    sudo apt-get install -y --no-install-recommends build-essential
+
+RUN pip install vllm==0.10.0

--- a/04_deploy_llama_3_70b/README.md
+++ b/04_deploy_llama_3_70b/README.md
@@ -2,7 +2,7 @@
 description: "Deploy Llama 3.1 70b with Ray Serve LLM."
 ---
 
-# Deploy Llama 3.1 8b
+# Deploy Llama 3.1 70b
 
 This example uses Ray Serve along with vLLM to deploy a Llama 3.1 70b model as an Anyscale service.
 
@@ -33,9 +33,9 @@ If you’re using an ungated model, go to your `LLMConfig` (in `serve_llama_3_1_
 
 ## Understanding the example
 
-- The [application code](https://github.com/anyscale/examples/blob/main/03_deploy_llama_3_8b/serve_llama_3_8b.py) sets the required accelerator type with `accelerator_type="L4"`. To use a different accelerator, replace `"L4"` with the desired name. See the [list of supported accelerators](https://docs.ray.io/en/latest/ray-core/accelerator-types.html#accelerator-types) for available options.
-- Ray Serve automatically autoscales the number of model replicas between `min_replicas` and `max_replicas`. Ray Serve adapts the number of replicas by monitoring queue sizes. For more details on configuring autoscaling, see the documentation [here](https://docs.ray.io/en/latest/serve/api/doc/ray.serve.config.AutoscalingConfig.html).
-- This example uses vLLM, and the [Dockerfile](https://github.com/anyscale/examples/blob/main/03_deploy_llama_3_8b/Dockerfile) defines the service’s dependencies. When you run `anyscale service deploy`, the build process adds these dependencies on top of an Anyscale-provided base image.
+- The [application code](https://github.com/anyscale/examples/blob/main/04_deploy_llama_3_70b/serve_llama_3_1_70b.py) sets the required accelerator type with `accelerator_type="A100"`. To use a different accelerator, replace `"A100"` with the desired name. See the [list of supported accelerators](https://docs.ray.io/en/latest/ray-core/accelerator-types.html#accelerator-types) for available options.
+- Ray Serve automatically autoscales the number of model replicas between `min_replicas` and `max_replicas`. Ray Serve adapts the number of replicas by monitoring queue sizes. For more information on configuring autoscaling, see the [AutoscalingConfig documentation](https://docs.ray.io/en/latest/serve/api/doc/ray.serve.config.AutoscalingConfig.html).
+- This example uses vLLM, and the [Dockerfile](https://github.com/anyscale/examples/blob/main/04_deploy_llama_3_70b/Dockerfile) defines the service’s dependencies. When you run `anyscale service deploy`, the build process adds these dependencies on top of an Anyscale-provided base image.
 - To configure vLLM, modify the `engine_kwargs` dictionary. See [Ray documentation for the `LLMConfig` object](https://docs.ray.io/en/latest/serve/api/doc/ray.serve.llm.LLMConfig.html#ray.serve.llm.LLMConfig).
 
 
@@ -46,7 +46,7 @@ The `anyscale service deploy` command outputs a line that looks like
 curl -H "Authorization: Bearer <SERVICE_TOKEN>" <BASE_URL>
 ```
 
-From the output, you can extract the service token and base URL. Open [query.py](https://github.com/anyscale/examples/blob/main/03_deploy_llama_3_8b/query.py) and add them to the appropriate fields.
+From the output, you can extract the service token and base URL. Open [query.py](https://github.com/anyscale/examples/blob/main/04_deploy_llama_3_70b/query.py) and add them to the appropriate fields.
 ```python
 token = <SERVICE_TOKEN> 
 base_url = <BASE_URL> 

--- a/04_deploy_llama_3_70b/README.md
+++ b/04_deploy_llama_3_70b/README.md
@@ -1,0 +1,61 @@
+---
+description: "Deploy Llama 3.1 70b with Ray Serve LLM."
+---
+
+# Deploy Llama 3.1 8b
+
+This example uses Ray Serve along with vLLM to deploy a Llama 3.1 70b model as an Anyscale service.
+
+## Install the Anyscale CLI
+
+```bash
+pip install -U anyscale
+anyscale login
+```
+
+## Deploy the service
+
+Clone the example from GitHub.
+
+```bash
+git clone https://github.com/anyscale/examples.git
+cd examples/04_deploy_llama_3_70b
+```
+
+Deploy the service. Use `--env` to forward your Hugging Face token if you need authentication for gated models like Llama 3.
+
+```bash
+export HF_TOKEN=***
+anyscale service deploy -f service.yaml --env HF_TOKEN=$HF_TOKEN
+```
+
+If you’re using an ungated model, go to your `LLMConfig` (in `serve_llama_3_1_70b.py`), and set `model_source` to that model. Then, you can omit the Hugging Face token from both the config and the `anyscale service deploy` command.
+
+## Understanding the example
+
+- The [application code](https://github.com/anyscale/examples/blob/main/03_deploy_llama_3_8b/serve_llama_3_8b.py) sets the required accelerator type with `accelerator_type="L4"`. To use a different accelerator, replace `"L4"` with the desired name. See the [list of supported accelerators](https://docs.ray.io/en/latest/ray-core/accelerator-types.html#accelerator-types) for available options.
+- Ray Serve automatically autoscales the number of model replicas between `min_replicas` and `max_replicas`. Ray Serve adapts the number of replicas by monitoring queue sizes. For more details on configuring autoscaling, see the documentation [here](https://docs.ray.io/en/latest/serve/api/doc/ray.serve.config.AutoscalingConfig.html).
+- This example uses vLLM, and the [Dockerfile](https://github.com/anyscale/examples/blob/main/03_deploy_llama_3_8b/Dockerfile) defines the service’s dependencies. When you run `anyscale service deploy`, the build process adds these dependencies on top of an Anyscale-provided base image.
+- To configure vLLM, modify the `engine_kwargs` dictionary. See [Ray documentation for the `LLMConfig` object](https://docs.ray.io/en/latest/serve/api/doc/ray.serve.llm.LLMConfig.html#ray.serve.llm.LLMConfig).
+
+
+## Query the service
+
+The `anyscale service deploy` command outputs a line that looks like  
+```text
+curl -H "Authorization: Bearer <SERVICE_TOKEN>" <BASE_URL>
+```
+
+From the output, you can extract the service token and base URL. Open [query.py](https://github.com/anyscale/examples/blob/main/03_deploy_llama_3_8b/query.py) and add them to the appropriate fields.
+```python
+token = <SERVICE_TOKEN> 
+base_url = <BASE_URL> 
+```
+
+Query the model  
+```bash
+pip install openai
+python query.py
+```
+
+View the service in the [services tab](https://console.anyscale.com/services) of the Anyscale console.

--- a/04_deploy_llama_3_70b/query.py
+++ b/04_deploy_llama_3_70b/query.py
@@ -1,0 +1,26 @@
+from urllib.parse import urljoin
+from openai import OpenAI
+
+# The "anyscale service deploy" script outputs a line that looks like
+# 
+#     curl -H "Authorization: Bearer <SERVICE_TOKEN>" <BASE_URL>
+# 
+# From this, you can parse out the service token and base URL.
+token = <SERVICE_TOKEN>  # Fill this in. If deploying and querying locally, use token = "FAKE_KEY"
+base_url = <BASE_URL>  # Fill this in. If deploying and querying locally, use base_url = "http://localhost:8000"
+
+client = OpenAI(base_url= urljoin(base_url, "v1"), api_key=token)
+
+response = client.chat.completions.create(
+    model="my-llama-3.1-70B",
+    messages=[
+        {"role": "user", "content": "What's the capital of France?"}
+    ],
+    stream=True
+)
+
+# Stream and print JSON
+for chunk in response:
+    data = chunk.choices[0].delta.content
+    if data:
+        print(data, end="", flush=True)

--- a/04_deploy_llama_3_70b/serve_llama_3_1_70b.py
+++ b/04_deploy_llama_3_70b/serve_llama_3_1_70b.py
@@ -1,0 +1,36 @@
+#serve_llama_3_1_70b.py
+from ray import serve
+from ray.serve.llm import LLMConfig, build_openai_app
+import os
+
+llm_config = LLMConfig(
+    model_loading_config=dict(
+        model_id="my-llama-3.1-70B",
+        # Or unsloth/Meta-Llama-3.1-70B-Instruct for an ungated model
+        model_source="meta-llama/Llama-3.1-70B-Instruct",
+    ),
+    accelerator_type="A100",
+    deployment_config=dict(
+        autoscaling_config=dict(
+            min_replicas=1, max_replicas=4,
+        )
+    ),
+    ### If your model is not gated, you can skip `hf_token`
+    # Share your Hugging Face Token to the vllm engine so it can access the gated Llama 3
+    # Type `export HF_TOKEN=<YOUR-HUGGINGFACE-TOKEN>` in a terminal
+    runtime_env=dict(
+        env_vars={
+            "HF_TOKEN": os.environ.get("HF_TOKEN")
+        }
+    ),
+    engine_kwargs=dict(
+        max_model_len=32768,
+        # Split weights among 8 GPUs in the node
+        tensor_parallel_size=8
+    )
+)
+
+app = build_openai_app({"llm_configs": [llm_config]})
+
+# Uncomment the below line to run the service locally with Python.
+# serve.run(app, blocking=True)

--- a/04_deploy_llama_3_70b/service.yaml
+++ b/04_deploy_llama_3_70b/service.yaml
@@ -1,0 +1,41 @@
+# View the docs https://docs.anyscale.com/reference/service-api#serviceconfig.
+
+name: deploy-llama-3-1-70b
+
+# When empty, use the default image. This can be an Anyscale-provided base image
+# like anyscale/ray:2.43.0-slim-py312-cu125, a user-provided base image (provided
+# that it meets certain specs), or you can build new images using the Anyscale
+# image builder at https://console.anyscale-staging.com/v2/container-images.
+
+containerfile: ./Dockerfile
+
+# When empty, Anyscale will auto-select the instance types. You can also specify
+# minimum and maximum resources.
+compute_config:
+#   head_node:
+#     instance_type: m5.2xlarge
+#   worker_nodes:
+#     - instance_type: m5.16xlarge
+#       min_nodes: 0
+#       max_nodes: 100
+#     - instance_type: m7a.24xlarge
+#       min_nodes: 0
+#       max_nodes: 100
+#       market_type: PREFER_SPOT # Defaults to ON_DEMAND
+#     - instance_type: g4dn.2xlarge
+#       min_nodes: 0
+#       max_nodes: 100
+#       market_type: PREFER_SPOT # Defaults to ON_DEMAND
+  auto_select_worker_config: true
+
+# Path to a local directory or a remote URI to a .zip file (S3, GS, HTTP) that
+# will be the working directory for the job. The files in the directory will be
+# automatically uploaded to the job environment in Anyscale.
+working_dir: .
+
+# When empty, this uses the default Anyscale Cloud in your organization.
+cloud:
+
+# Specify the Ray Serve app to deploy.
+applications:
+- import_path: serve_llama_3_1_70b:app


### PR DESCRIPTION
Add a tutorial on deploying llama 3.1 8b-instruct.

Follow the same format as the llama 3.1 8b example for consistency (see this PR: [https://github.com/anyscale/examples/pull/12](https://github.com/anyscale/examples/pull/12)).

As with the reasoning for choosing L4 GPUs in the Llama 3 8B example, here we use 8×A100 GPUs, which are available in both our AWS and GCP clouds.

I didn't have a chance to test it with ray 2.49 (it's taking hours to launch a 8xA100 instance.. maybe someone else can have more luck) but it worked with 2.48. I'll try to test again later this week
