### PR TITLE
Use required_labels to specify accelerator type for the WideEP example

### DIFF
--- a/wide_ep_fault_tolerance/service.yaml
+++ b/wide_ep_fault_tolerance/service.yaml
@@ -13,8 +13,9 @@ compute_config:
     - required_resources:
         CPU: 48
         GPU: 4
-        accelerator: L4
         memory: 192Gi
+      required_labels:
+        ray.io/accelerator-type: L4
       min_nodes: 1
       max_nodes: 2
 


### PR DESCRIPTION
Align with https://docs.anyscale.com/configuration/compute/declarative#required-labels: Use `required_labels` to specify accelerator type.

Verified by deploying the service with CC.