### PR TITLE
readme: remove duplicate 'Clone this repository' line in jax_training

### DIFF
--- a/jax_training/README.md
+++ b/jax_training/README.md
@@ -11,8 +11,6 @@ anyscale login
 
 ## Submit the job
 
-Clone this repository
-
 Clone the example from GitHub.
 
 ```bash


### PR DESCRIPTION
Remove the spurious leftover line 'Clone this repository' that appeared immediately before 'Clone the example from GitHub.' in the Submit the job section. The duplicate was inconsistent with all other example READMEs.