### PR TITLE
Add READMEs for 01_job_hello_world and 02_service_hello_world

### DIFF
--- a/01_job_hello_world/README.md
+++ b/01_job_hello_world/README.md
@@ -1,4 +1,3 @@
-
 # Get started with jobs
 
 Run discrete workloads in production such as batch inference, bulk embeddings generation, or model fine-tuning.

--- a/01_job_hello_world/README.md
+++ b/01_job_hello_world/README.md
@@ -53,4 +53,4 @@ anyscale job submit -f job.yaml
 
 ## 3. Inspect the results
 
-Navigate to the Anyscale [**Jobs** page](https://console.anyscale.com/v2/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/jobs) and take a look at the results.
+Navigate to the Anyscale [**Jobs** page](https://console.anyscale.com/jobs) and take a look at the results.

--- a/01_job_hello_world/README.md
+++ b/01_job_hello_world/README.md
@@ -1,0 +1,57 @@
+
+# Get started with jobs
+
+Run discrete workloads in production such as batch inference, bulk embeddings generation, or model fine-tuning.
+
+---
+
+Anyscale jobs allow you to submit applications developed on workspaces to a standalone Ray cluster for execution. Built for production and designed to fit into your CI/CD pipeline, jobs ensure scalable and reliable performance.
+
+Run your first job with the following instructions.
+
+## 1. Install the Anyscale CLI
+
+```bash
+pip install -U anyscale
+anyscale login
+```
+
+## 2. Submit a job
+
+Clone the example from GitHub.
+
+```bash
+git clone https://github.com/anyscale/examples.git
+cd examples/01_job_hello_world
+```
+
+The code in [main.py](https://github.com/anyscale/examples/blob/main/01_job_hello_world/main.py) runs 100 tasks that each take a number and square it.
+
+```python
+import os
+import ray
+
+
+@ray.remote
+def f(i):
+    # This print statement is running in a separate worker process.
+    print(f"The value of EXAMPLE_ENV_VAR is {os.environ['EXAMPLE_ENV_VAR']}.")
+    return i ** 2
+
+
+# Execute 100 tasks across the cluster.
+results = ray.get([f.remote(i) for i in range(100)])
+print(results)
+```
+
+Also take a look at `job.yaml`. This file specifies the container image, compute resources, script entrypoint, and a few other fields.
+
+Submit the job:
+
+```bash
+anyscale job submit -f job.yaml
+```
+
+## 3. Inspect the results
+
+Navigate to the Anyscale [**Jobs** page](https://console.anyscale.com/v2/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/jobs) and take a look at the results.

--- a/02_service_hello_world/README.md
+++ b/02_service_hello_world/README.md
@@ -1,0 +1,61 @@
+
+# Get started with services
+
+Deploy your machine learning applications in production using [Ray Serve](https://docs.ray.io/en/latest/serve/index.html), an open-source, distributed serving library for building online inference APIs.
+
+---
+
+Deploy your first service with the following instructions.
+
+## 1. Install the Anyscale CLI
+
+``` bash
+pip install -U anyscale
+anyscale login
+```
+
+## 2. Deploy a service
+
+Clone the example from GitHub.
+
+``` bash
+git clone https://github.com/anyscale/examples.git
+cd examples/02_service_hello_world
+```
+
+The code for an endpoint that says "hello" is in [main.py](https://github.com/anyscale/examples/blob/main/02_service_hello_world/main.py).
+
+Also take a look at `service.yaml`. This file specifies the container image, compute resources, script entrypoint, and a few other fields.
+
+Deploy the service:
+
+``` bash
+anyscale service deploy -f ./service.yaml
+```
+
+## 3. Query the service
+
+Once the service is running, query it as follows:
+
+```python
+import requests
+
+# The "anyscale service deploy" script outputs a line that looks like
+#
+#     curl -H "Authorization: Bearer <SERVICE_TOKEN>" <BASE_URL>
+#
+# From this, you can parse out the service token and base URL.
+token = <SERVICE_TOKEN>  # Fill this in.
+base_url = <BASE_URL>  # Fill this in.
+
+resp = requests.get(
+    f"{base_url}/hello",
+    params={"name": "Theodore"},
+    headers={"Authorization": f"Bearer {token}"})
+
+print(resp.text)
+```
+
+## 4. Monitor the service
+
+Navigate over to the Anyscale [**Services** page](https://console.anyscale.com/v2/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/services?sortColumn=status&sortOrder=DESC) and check up on your deployment.

--- a/02_service_hello_world/README.md
+++ b/02_service_hello_world/README.md
@@ -1,4 +1,3 @@
-
 # Get started with services
 
 Deploy your machine learning applications in production using [Ray Serve](https://docs.ray.io/en/latest/serve/index.html), an open-source, distributed serving library for building online inference APIs.

--- a/02_service_hello_world/README.md
+++ b/02_service_hello_world/README.md
@@ -57,4 +57,4 @@ print(resp.text)
 
 ## 4. Monitor the service
 
-Navigate over to the Anyscale [**Services** page](https://console.anyscale.com/v2/cld_kvedZWag2qA8i5BjxUevf5i7/prj_cz951f43jjdybtzkx1s5sjgz99/services?sortColumn=status&sortOrder=DESC) and check up on your deployment.
+Navigate over to the Anyscale [**Services** page](https://console.anyscale.com/services) and check up on your deployment.


### PR DESCRIPTION
Add READMEs for the two hello-world examples that were missing them. Content is copied from the corresponding tutorial pages in the docs repo (anyscale/docs), with front matter and Docusaurus-specific anchors stripped.
