### PR TITLE
Add video captioning example: raw Ray Core vs Ray Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Curated trails through the map. Follow one top to bottom — each stop builds on
 [fineweb_dedup](fineweb_dedup/) → [megatron_training](megatron_training/) → [skyrl](skyrl/) → [deploy_llama_3_8b](deploy_llama_3_8b/) → [wide_ep_fault_tolerance](wide_ep_fault_tolerance/)
 
 **Pretraining data factory** — web-scale curation across text, image, and video.
-[fineweb_dedup](fineweb_dedup/) → [image_processing](image_processing/) → [video_curation](video_curation/)
+[fineweb_dedup](fineweb_dedup/) → [image_processing](image_processing/) → [video_curation](video_curation/) → [video_captioning](video_captioning/)
 
 **Train and align** — from a first distributed run to Megatron-parallel SFT to RL.
 [jax_training](jax_training/) → [megatron_training](megatron_training/) → [skyrl](skyrl/)
@@ -45,6 +45,7 @@ Curated trails through the map. Follow one top to bottom — each stop builds on
 | [fineweb_dedup](fineweb_dedup/) | Clean, filter, and MinHash-dedup the FineWeb-edu corpus | Data-Juicer, Ray Data | job |
 | [image_processing](image_processing/) | Caption 2B image URLs with a vision-language model | Ray Data, vLLM, Qwen2.5-VL | job |
 | [video_curation](video_curation/) | Stream raw video into annotated, embedded clip datasets | Ray Data, vLLM, CLIP | job |
+| [video_captioning](video_captioning/) | Caption video at scale, comparing raw Ray Core against Ray Data | Ray Core, Ray Data, vLLM, Qwen3-VL | job |
 
 ### 2 · Train — distributed training on heterogeneous clusters
 
@@ -88,7 +89,7 @@ This cookbook exists because of the open-source projects below. Each example's R
 | Project | What it does here | Used in |
 |---|---|---|
 | [Ray](https://github.com/ray-project/ray) | Distributed compute engine under everything: Ray Data, Ray Train, Ray Serve, Ray Core | all examples |
-| [vLLM](https://github.com/vllm-project/vllm) | High-throughput LLM inference engine | image_processing, video_curation, skyrl, deploy_llama_3_8b, deploy_llama_3_1_70b, wide_ep_fault_tolerance, fast_model_loading_gcs_nvme |
+| [vLLM](https://github.com/vllm-project/vllm) | High-throughput LLM inference engine | image_processing, video_curation, video_captioning, skyrl, deploy_llama_3_8b, deploy_llama_3_1_70b, wide_ep_fault_tolerance, fast_model_loading_gcs_nvme |
 | [SGLang](https://github.com/sgl-project/sglang) | Tensor- and pipeline-parallel inference engine | sglang_inference |
 | [Megatron-LM](https://github.com/NVIDIA/Megatron-LM) | Parallel transformer training core | megatron_training |
 | [Megatron-Bridge](https://github.com/NVIDIA-NeMo/Megatron-Bridge) | Hugging Face ↔ Megatron bridge and training recipes | megatron_training |

--- a/video_captioning/Dockerfile
+++ b/video_captioning/Dockerfile
@@ -1,0 +1,24 @@
+# Ray 2.56 ray-llm base: py312 + cu130 (CUDA 13 supports Blackwell sm_120) and
+# a recent vLLM with Qwen3-VL support.
+FROM anyscale/ray-llm:2.56.0-py312-cu130
+
+# System deps: gcc + libc6-dev for vLLM's Triton JIT; ffmpeg + GL/GLib for
+# decord video decoding.
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+    gcc \
+    libc6-dev \
+    ffmpeg \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# qwen-vl-utils supports Qwen3-VL offline inference; decord decodes the clips;
+# pynvml/psutil power the utilization sampler.
+RUN pip install --no-cache-dir \
+    "qwen-vl-utils==0.0.14" \
+    opencv-python-headless \
+    decord \
+    huggingface_hub \
+    pynvml \
+    psutil \
+    "numpy<2.0.0"

--- a/video_captioning/README.md
+++ b/video_captioning/README.md
@@ -1,0 +1,129 @@
+# Video captioning at scale: raw Ray Core vs Ray Data
+
+This example captions a video corpus with a vision-language model twice — once
+hand-built on [Ray Core](https://docs.ray.io/en/latest/ray-core/walkthrough.html)
+and once on [Ray Data](https://docs.ray.io/en/latest/data/data.html) — so you can
+compare throughput, GPU/CPU utilization, and code complexity on identical
+hardware. Both read [FineVideo](https://huggingface.co/datasets/HuggingFaceFV/finevideo),
+decode and sample keyframes on CPU, and caption each clip with
+[Qwen3-VL](https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct) served by
+[vLLM](https://github.com/vllm-project/vllm), one replica per GPU.
+
+## The stack
+
+| Layer | Library | Role in this example |
+|---|---|---|
+| Orchestration (baseline) | [Ray Core](https://docs.ray.io/en/latest/ray-core/walkthrough.html) | hand-rolled tasks + actors + a manual backpressure loop |
+| Orchestration (framework) | [Ray Data](https://docs.ray.io/en/latest/data/data.html) | the same DAG as a streaming pipeline with automatic backpressure |
+| Inference | [vLLM](https://github.com/vllm-project/vllm) | high-throughput batched VLM inference, one engine per GPU |
+| Model | [Qwen3-VL](https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct) | captions an ordered sequence of keyframes per clip |
+| Dataset | [FineVideo](https://huggingface.co/datasets/HuggingFaceFV/finevideo) | source video corpus, streamed from Hugging Face or object storage |
+| Platform | [Anyscale](https://www.anyscale.com) | image build, compute provisioning, job/service management |
+
+## Pipeline
+
+The example is three files. Both implementations run exactly the same two
+compute-heavy stages — defined once in
+[`utils.py`](https://github.com/anyscale/ai-infra-cookbook/blob/main/video_captioning/utils.py)
+— so only the orchestration differs.
+
+```
+FineVideo parquet (mp4 bytes)
+    |
+    +-- decode + uniform keyframe sample   # CPU: decord open, N frames per clip
+    |
+    +-- Qwen3-VL caption                    # GPU: vLLM, one replica per GPU
+    |
+    +-- write parquet + report.json         # captions + throughput/utilization
+```
+
+The **baseline** ([`caption_ray_core.py`](https://github.com/anyscale/ai-infra-cookbook/blob/main/video_captioning/caption_ray_core.py))
+builds this out of Ray Core primitives: shard-reader/decode tasks, a pool of
+GPU caption actors, and a hand-written scheduling loop that caps in-flight work
+at each stage, batches decoded rows, and round-robins them across the actors.
+The **rebuild** ([`caption_ray_data.py`](https://github.com/anyscale/ai-infra-cookbook/blob/main/video_captioning/caption_ray_data.py))
+expresses the same DAG in a handful of Ray Data operators and gets streaming,
+backpressure, fault tolerance, and autoscaling for free.
+
+## Install the Anyscale CLI
+
+```bash
+pip install -U anyscale
+anyscale login
+```
+
+## Submit the job
+
+Clone the example from GitHub.
+
+```bash
+git clone https://github.com/anyscale/ai-infra-cookbook.git
+cd ai-infra-cookbook/video_captioning
+```
+
+[FineVideo](https://huggingface.co/datasets/HuggingFaceFV/finevideo) is a gated
+Hugging Face dataset, so you **must** pass an `HF_TOKEN`. Run the Ray Data
+pipeline on a small slice first:
+
+```bash
+export HF_TOKEN=hf_...
+
+anyscale job submit -f job_ray_data.yaml --env HF_TOKEN=$HF_TOKEN --env NUM_VIDEOS=500
+```
+
+Then run the raw Ray Core baseline on the same slice to compare:
+
+```bash
+anyscale job submit -f job_ray_core.yaml --env HF_TOKEN=$HF_TOKEN --env NUM_VIDEOS=500
+```
+
+Omit `NUM_VIDEOS` to process the whole dataset. Pass `--env INPUT=<uri>` to
+read from object storage instead of Hugging Face and `--env OUTPUT=<uri>` to
+choose where captions land (default: a timestamped prefix under
+`$ANYSCALE_ARTIFACT_STORAGE/video_captioning/`).
+
+## Understanding the example
+
+- [`utils.py`](https://github.com/anyscale/ai-infra-cookbook/blob/main/video_captioning/utils.py)
+  holds the *work*, shared by both pipelines: `decode_and_sample` does the CPU
+  stage (decord open, uniform keyframe sample, JPEG encode) and the message
+  builders construct the Qwen3-VL prompt. Because the work is identical, any
+  throughput difference comes from orchestration.
+- [`caption_ray_core.py`](https://github.com/anyscale/ai-infra-cookbook/blob/main/video_captioning/caption_ray_core.py)
+  is intentionally explicit: it shows every piece of scheduling a framework
+  normally hides — in-flight caps per stage, manual batching, round-robin
+  dispatch, and partial-batch draining — and it hand-rolls no fault tolerance,
+  so a dead actor fails the run.
+- [`caption_ray_data.py`](https://github.com/anyscale/ai-infra-cookbook/blob/main/video_captioning/caption_ray_data.py)
+  uses the native [`ray.data.llm`](https://docs.ray.io/en/latest/data/api/llm.html)
+  vLLM integration. The read stage is pinned to `cpu_only`-labeled nodes so
+  multi-MB mp4 blobs never share RAM with the GPU engines.
+- Qwen3-VL-8B runs one replica per GPU with no tensor parallelism — it fits
+  comfortably on a 96 GB RTX PRO 6000, which maximizes throughput.
+
+## Measuring throughput and utilization
+
+Every run writes `report.json` next to its captions with:
+
+- **Throughput** — captions/sec, captions/GPU/sec, and video-hours processed
+  per wall-clock hour.
+- **GPU utilization** (NVML) and **CPU utilization** (psutil), mean and p95, so
+  you can see whether decode is keeping the GPUs fed or starving them.
+
+## Scaling the run
+
+The committed job YAMLs default to an 8-GPU smoke test (one GPU worker node).
+To scale, edit the GPU worker pool's `min_nodes`/`max_nodes` in the YAML and
+pass a matching `--env EXPECTED_GPUS=<n>` so the driver waits for the full
+fleet before starting the clock: 8 nodes for 64 GPUs, 32 nodes for 256 GPUs.
+
+## Position in the stack
+
+**Stage:** Curate
+
+- **Related:** [Streaming video curation with Ray Data](../video_curation/) — same video modality; that example curates, this one benchmarks captioning throughput
+- **Downstream:** [SFT with Megatron-Bridge and Ray Train](../megatron_training/) — captioned clip datasets feed multimodal training
+- **Journeys:** [Pretraining data factory](../README.md#journeys)
+
+Part of the [Open-Source Frontier Infra Stack](../README.md) — explore the
+map in the [interactive explorer](../README.md#interactive-explorer).

--- a/video_captioning/caption_ray_core.py
+++ b/video_captioning/caption_ray_core.py
@@ -1,0 +1,277 @@
+"""Video captioning hand-built on Ray Core — the baseline half of the example.
+
+The pipeline is read → CPU decode → GPU caption → write. Here every piece of
+orchestration is written by hand out of Ray Core primitives:
+
+    shards ──(read_and_decode_shard tasks)──► {keyframes, metadata}   CPU pool
+           ──(CaptionActor.caption)──────────► {caption, metadata}    one actor / GPU
+           ──(pyarrow write)──────────────────► parquet parts
+
+The driver loop below does its own backpressure (capping in-flight tasks per
+stage), batches decoded rows into VLM-sized requests, round-robins them across
+the GPU actor pool, and drains the final partial batch. It also has no fault
+tolerance — a dead task or actor fails the run. caption_ray_data.py expresses
+the same DAG in a few Ray Data operators and gets all of that for free; that
+contrast is the point of the example.
+
+Usage:
+    python caption_ray_core.py --num-videos 500
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+from collections import deque
+from typing import Any, Dict, List, Optional
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import ray
+from huggingface_hub import HfFileSystem
+
+from utils import (
+    MAX_MODEL_LEN,
+    MODEL_SOURCE,
+    NUM_KEYFRAMES,
+    OUTPUT_COLUMNS,
+    VLM_BATCH_SIZE,
+    UtilizationMonitor,
+    build_messages_b64,
+    clean_caption,
+    decode_and_sample,
+    default_output,
+    filesystem_and_path,
+    sampling_params,
+    wait_for_gpus,
+    worker_setup,
+    write_report,
+)
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+)
+logger = logging.getLogger("video_captioning")
+
+
+# ---------------------------------------------------------------------------
+# Stage tasks / actors
+# ---------------------------------------------------------------------------
+
+
+@ray.remote(num_cpus=1)
+def read_and_decode_shard(
+    path: str, hf_token: Optional[str], is_hf: bool
+) -> List[Dict[str, Any]]:
+    """Read one parquet shard's mp4 column and decode each clip to keyframes.
+
+    Read and decode are fused into one task on purpose: the task returns only
+    the compact keyframe payloads (a few MB), never the multi-MB mp4 blobs, so
+    the driver's scheduling loop never pulls raw video into head-node memory.
+    """
+    if is_hf:
+        fs = HfFileSystem(token=hf_token)
+        with fs.open(path, "rb") as f:
+            table = pq.read_table(f, columns=["mp4"])
+    else:
+        fs, rel = filesystem_and_path(path)
+        table = pq.read_table(rel, filesystem=fs, columns=["mp4"])
+
+    decoded = []
+    for mp4 in table.column("mp4").to_pylist():
+        payload = decode_and_sample(mp4)
+        if payload is not None:
+            decoded.append(payload)
+    return decoded
+
+
+@ray.remote(num_gpus=1)
+class CaptionActor:
+    """GPU stage: a persistent vLLM engine, one per GPU. No tensor parallelism —
+    Qwen3-VL-8B fits comfortably on a single 96 GB GPU."""
+
+    def __init__(self):
+        from vllm import LLM
+
+        worker_setup()
+        self.llm = LLM(
+            model=MODEL_SOURCE,
+            max_model_len=MAX_MODEL_LEN,
+            limit_mm_per_prompt={"image": NUM_KEYFRAMES},
+            gpu_memory_utilization=0.90,
+            mm_processor_cache_gb=0,  # inputs are unique; skip the cache overhead
+            trust_remote_code=True,
+        )
+
+    def caption(self, batch: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        from vllm import SamplingParams
+
+        conversations = [build_messages_b64(list(r["keyframes"])) for r in batch]
+        outputs = self.llm.chat(conversations, SamplingParams(**sampling_params()), use_tqdm=False)
+        results = []
+        for row, out in zip(batch, outputs):
+            result = {c: row[c] for c in OUTPUT_COLUMNS if c != "caption"}
+            result["caption"] = clean_caption(out.outputs[0].text)
+            results.append(result)
+        return results
+
+    def ready(self) -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Input enumeration + output writing
+# ---------------------------------------------------------------------------
+
+
+def enumerate_shards(input_uri: str, hf_token: Optional[str]) -> tuple:
+    """Return (list_of_shard_paths, is_hf)."""
+    import pyarrow.fs
+
+    if input_uri.startswith("hf://"):
+        fs = HfFileSystem(token=hf_token)
+        paths = fs.glob(f"{input_uri[len('hf://'):]}/**/*.parquet")
+        return sorted(paths), True
+    fs, rel = filesystem_and_path(input_uri)
+    infos = fs.get_file_info(pyarrow.fs.FileSelector(rel, recursive=True))
+    prefix = input_uri.split("://", 1)[0] + "://" if "://" in input_uri else ""
+    paths = [prefix + i.path for i in infos if i.path.endswith(".parquet")]
+    return sorted(paths), False
+
+
+def write_chunk(rows: List[Dict[str, Any]], output_uri: str, part_idx: int):
+    """Write one output parquet part."""
+    table = pa.table({c: [r[c] for r in rows] for c in OUTPUT_COLUMNS})
+    name = f"part-{part_idx:05d}.parquet"
+    if "://" in output_uri:
+        fs, rel = filesystem_and_path(output_uri)
+        with fs.open_output_stream(f"{rel}/{name}") as f:
+            pq.write_table(table, f)
+    else:
+        os.makedirs(output_uri, exist_ok=True)
+        pq.write_table(table, os.path.join(output_uri, name))
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled streaming scheduler
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Video captioning on raw Ray Core.")
+    parser.add_argument("--input", default="hf://datasets/HuggingFaceFV/finevideo")
+    parser.add_argument("--output", default=None)
+    parser.add_argument("--num-videos", type=int, default=None)
+    parser.add_argument("--write-chunk-rows", type=int, default=2000)
+    args = parser.parse_args()
+    output = args.output or default_output("ray_core")
+
+    hf_token = os.environ.get("HF_TOKEN")
+    if args.input.startswith("hf://") and not hf_token:
+        logger.error("HF_TOKEN is required to read %s", args.input)
+        sys.exit(1)
+
+    ray.init(ignore_reinit_error=True)
+    num_gpus = wait_for_gpus(min_gpus=int(os.environ.get("EXPECTED_GPUS", "8")))
+    if num_gpus < 1:
+        logger.error("No GPUs joined the cluster within the timeout.")
+        sys.exit(1)
+
+    # Manual backpressure caps — the knobs Ray Data sets automatically.
+    max_shard_tasks = max(8, int(ray.cluster_resources().get("CPU", 0)))
+    max_caption_tasks = num_gpus * 2  # two batches in flight per GPU hides dispatch latency
+
+    shard_paths, is_hf = enumerate_shards(args.input, hf_token)
+    limit = args.num_videos
+    logger.info("input=%s (%d shards)  model=%s  GPUs=%d  output=%s",
+                args.input, len(shard_paths), MODEL_SOURCE, num_gpus, output)
+
+    # Spin up one caption actor per GPU and block on weight load so the timed
+    # region measures steady-state throughput, not cold start.
+    actors = [CaptionActor.remote() for _ in range(num_gpus)]
+    logger.info("Loading %d vLLM engines (one per GPU)...", num_gpus)
+    ray.get([a.ready.remote() for a in actors])
+    logger.info("Engines ready.")
+
+    monitor = UtilizationMonitor().start()
+    t0 = time.time()
+
+    shard_q = deque(shard_paths)
+    decoded_q: deque = deque()
+    inflight: Dict[Any, str] = {}  # ObjectRef -> "shard" | "caption"
+    videos_enqueued = 0
+    captions_done = 0
+    total_video_seconds = 0.0
+    result_buffer: List[Dict[str, Any]] = []
+    part_idx = 0
+    actor_rr = 0
+
+    def n(kind: str) -> int:
+        return sum(1 for k in inflight.values() if k == kind)
+
+    def limit_reached() -> bool:
+        return limit is not None and videos_enqueued >= limit
+
+    while shard_q or decoded_q or inflight:
+        # 1. Keep read+decode tasks flowing (unless we've hit --num-videos).
+        while shard_q and n("shard") < max_shard_tasks and not limit_reached():
+            ref = read_and_decode_shard.remote(shard_q.popleft(), hf_token, is_hf)
+            inflight[ref] = "shard"
+
+        # 2. Dispatch full VLM batches round-robin across the actor pool.
+        while len(decoded_q) >= VLM_BATCH_SIZE and n("caption") < max_caption_tasks:
+            batch = [decoded_q.popleft() for _ in range(VLM_BATCH_SIZE)]
+            inflight[actors[actor_rr % num_gpus].caption.remote(batch)] = "caption"
+            actor_rr += 1
+
+        # 3. Drain the final partial batch once no more decoded rows will arrive.
+        decoding_done = n("shard") == 0 and (not shard_q or limit_reached())
+        if decoding_done and decoded_q and n("caption") < max_caption_tasks:
+            batch = [decoded_q.popleft() for _ in range(len(decoded_q))]
+            inflight[actors[actor_rr % num_gpus].caption.remote(batch)] = "caption"
+            actor_rr += 1
+
+        if not inflight:
+            continue
+
+        # 4. Wait for any in-flight task and route its result onward.
+        ready_refs, _ = ray.wait(list(inflight.keys()), num_returns=1)
+        ref = ready_refs[0]
+        kind = inflight.pop(ref)
+        out = ray.get(ref)
+        if kind == "shard":
+            take = out if limit is None else out[: max(0, limit - videos_enqueued)]
+            decoded_q.extend(take)
+            videos_enqueued += len(take)
+            if limit_reached():
+                shard_q.clear()
+        else:  # caption
+            captions_done += len(out)
+            total_video_seconds += sum(r["duration_sec"] for r in out)
+            result_buffer.extend(out)
+            if len(result_buffer) >= args.write_chunk_rows:
+                write_chunk(result_buffer, output, part_idx)
+                part_idx += 1
+                result_buffer = []
+            logger.info(
+                "captions=%d  decoded_q=%d  inflight[shard=%d cap=%d]",
+                captions_done, len(decoded_q), n("shard"), n("caption"),
+            )
+
+    if result_buffer:
+        write_chunk(result_buffer, output, part_idx)
+
+    write_report(
+        pipeline="ray_core",
+        num_gpus=num_gpus,
+        num_captions=captions_done,
+        video_seconds=total_video_seconds,
+        wall_seconds=time.time() - t0,
+        utilization=monitor.stop(),
+        output_uri=output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/video_captioning/caption_ray_data.py
+++ b/video_captioning/caption_ray_data.py
@@ -1,0 +1,163 @@
+"""The same video captioning pipeline, rebuilt on Ray Data.
+
+The DAG is identical to caption_ray_core.py — read → CPU decode → GPU caption
+→ write — but every piece of orchestration hand-rolled there (in-flight caps,
+batching, round-robin dispatch, partial-batch draining, backpressure, fault
+tolerance) is now the framework's job:
+
+    read_parquet(...)                # streamed, pinned to cpu_only nodes
+        .flat_map(decode_row)        # CPU: decode + uniform keyframe sample
+        |> vLLMEngineProcessor       # GPU: Qwen3-VL, one replica per GPU
+        .write_parquet(...)          # terminal op triggers the stream
+
+Ray Data streams blocks between stages with automatic backpressure, so the CPU
+decode stage and the GPU caption stage run concurrently and each stays busy.
+Compare report.json from this run against the Ray Core run: same hardware, far
+less code — how do throughput and GPU/CPU utilization compare?
+
+Usage:
+    python caption_ray_data.py --num-videos 500
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+
+import ray
+from huggingface_hub import HfFileSystem
+from ray.data.llm import (
+    PrepareImageStageConfig,
+    build_processor,
+    vLLMEngineProcessorConfig,
+)
+
+from utils import (
+    MAX_MODEL_LEN,
+    MODEL_SOURCE,
+    NUM_KEYFRAMES,
+    VLM_BATCH_SIZE,
+    UtilizationMonitor,
+    decode_row,
+    default_output,
+    filesystem_and_path,
+    vlm_postprocess,
+    vlm_preprocess,
+    wait_for_gpus,
+    worker_setup,
+    write_report,
+)
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+)
+logger = logging.getLogger("video_captioning")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Video captioning on Ray Data.")
+    parser.add_argument("--input", default="hf://datasets/HuggingFaceFV/finevideo")
+    parser.add_argument("--output", default=None)
+    parser.add_argument("--num-videos", type=int, default=None)
+    args = parser.parse_args()
+    output = args.output or default_output("ray_data")
+
+    hf_token = os.environ.get("HF_TOKEN")
+    if args.input.startswith("hf://") and not hf_token:
+        logger.error("HF_TOKEN is required to read %s", args.input)
+        sys.exit(1)
+
+    ray.init(
+        ignore_reinit_error=True,
+        runtime_env={"worker_process_setup_hook": worker_setup},
+    )
+    num_gpus = wait_for_gpus(min_gpus=int(os.environ.get("EXPECTED_GPUS", "8")))
+    if num_gpus < 1:
+        logger.error("No GPUs joined the cluster within the timeout.")
+        sys.exit(1)
+    logger.info("input=%s  model=%s  GPUs=%d  output=%s",
+                args.input, MODEL_SOURCE, num_gpus, output)
+
+    # ---- Stage 0: streamed parquet read, pinned to CPU-only nodes ----------
+    # Pinning the multi-MB mp4 read to cpu_only-labeled workers keeps big blobs
+    # off the GPU nodes; downstream stages are unpinned.
+    read_kwargs = dict(
+        columns=["mp4"],
+        file_extensions=["parquet"],
+        ray_remote_args={"label_selector": {"cpu_only": "true"}},
+    )
+    input_path = args.input
+    if args.input.startswith("hf://"):
+        read_kwargs["filesystem"] = HfFileSystem(token=hf_token)
+    elif "://" in args.input:
+        read_kwargs["filesystem"], input_path = filesystem_and_path(args.input)
+    ds = ray.data.read_parquet(input_path, **read_kwargs)
+    if args.num_videos is not None:
+        ds = ds.limit(args.num_videos)
+
+    # ---- Stage 1: CPU decode + keyframe sample (1 video -> 0/1 rows) -------
+    ds = ds.flat_map(decode_row, num_cpus=1)
+
+    # ---- Stage 2: GPU VLM caption (Qwen3-VL, one engine per GPU) -----------
+    config_kwargs = dict(
+        model_source=MODEL_SOURCE,
+        engine_kwargs={
+            "max_model_len": MAX_MODEL_LEN,
+            "gpu_memory_utilization": 0.90,
+            "limit_mm_per_prompt": {"image": NUM_KEYFRAMES},
+            "mm_processor_cache_gb": 0,  # inputs are unique; skip the cache
+            "trust_remote_code": True,
+            # Small runs stay eager; large runs amortize CUDA-graph capture.
+            "enforce_eager": (args.num_videos or 10**6) < 200,
+        },
+        batch_size=VLM_BATCH_SIZE,
+        concurrency=num_gpus,
+        prepare_image_stage=PrepareImageStageConfig(enabled=True),
+        should_continue_on_error=True,
+    )
+    # Pin engine replicas to a specific GPU pool when the label is present;
+    # set ACCELERATOR_TYPE="" for a mixed-GPU cluster.
+    accelerator = os.environ.get("ACCELERATOR_TYPE", "RTX-PRO-6000")
+    if accelerator:
+        config_kwargs["accelerator_type"] = accelerator
+
+    vlm_processor = build_processor(
+        vLLMEngineProcessorConfig(**config_kwargs),
+        preprocess=vlm_preprocess,
+        postprocess=vlm_postprocess,
+    )
+    ds = vlm_processor(ds)
+
+    monitor = UtilizationMonitor().start()
+    t0 = time.time()
+
+    # ---- Stage 3: terminal write (this is what actually runs the stream) ---
+    # try_create_dir=False skips the pre-write existence check, which some
+    # object stores reject (they have no real directories).
+    if "://" in output:
+        write_fs, write_path = filesystem_and_path(output)
+        ds.write_parquet(write_path, filesystem=write_fs, try_create_dir=False)
+    else:
+        write_fs, write_path = None, output
+        ds.write_parquet(write_path)
+
+    wall = time.time() - t0
+    utilization = monitor.stop()
+
+    # Read the captions back (small: metadata + text, no images) to tally exact
+    # counts and total video-seconds for the report.
+    out_ds = ray.data.read_parquet(write_path, filesystem=write_fs)
+    write_report(
+        pipeline="ray_data",
+        num_gpus=num_gpus,
+        num_captions=out_ds.count(),
+        video_seconds=float(out_ds.sum("duration_sec") or 0.0),
+        wall_seconds=wall,
+        utilization=utilization,
+        output_uri=output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/video_captioning/job_ray_core.yaml
+++ b/video_captioning/job_ray_core.yaml
@@ -1,0 +1,59 @@
+name: video-captioning-ray-core
+
+containerfile: ./Dockerfile
+
+# Same cluster shape as job_ray_data.yaml — the Ray Core baseline runs on
+# identical hardware so the two reports compare apples to apples.
+compute_config:
+  cloud: rkn-gpu-cloud
+  cloud_resource: coreweave-use14a
+
+  advanced_instance_config:
+    metadata:
+      labels:
+        kueue.x-k8s.io/queue-name: default-queue
+
+  # Head node is control-plane only (no GPU) — GPUs live in the worker pool.
+  head_node:
+    required_resources:
+      CPU: 32
+      memory: 128Gi
+
+  worker_nodes:
+    # ── GPU pool: one Qwen3-VL-8B engine per RTX PRO 6000 (8 GPUs/node) ────
+    # SCALE LADDER — set min_nodes = max_nodes AND pass --env EXPECTED_GPUS:
+    #    8 GPUs (smoke) -> 1 node,   EXPECTED_GPUS=8
+    #   64 GPUs         -> 8 nodes,  EXPECTED_GPUS=64
+    #  256 GPUs         -> 32 nodes, EXPECTED_GPUS=256
+    - required_resources:
+        CPU: 120
+        memory: 960Gi
+        GPU: 8
+      required_labels:
+        ray.io/accelerator-type: RTX-PRO-6000
+      advanced_instance_config:
+        metadata:
+          labels:
+            kueue.x-k8s.io/queue-name: default-queue
+      min_nodes: 1
+      max_nodes: 1
+
+    # ── CPU-only pool: shard reads + decode tasks ──────────────────────────
+    - required_resources:
+        CPU: 120
+        memory: 480Gi
+      labels:
+        cpu_only: "true"
+      advanced_instance_config:
+        metadata:
+          labels:
+            kueue.x-k8s.io/queue-name: default-queue
+      min_nodes: 1
+      max_nodes: 8
+
+working_dir: .
+
+entrypoint: python caption_ray_core.py ${NUM_VIDEOS:+--num-videos ${NUM_VIDEOS}} ${INPUT:+--input ${INPUT}} ${OUTPUT:+--output ${OUTPUT}}
+
+max_retries: 2
+timeout_s: 86400

--- a/video_captioning/job_ray_data.yaml
+++ b/video_captioning/job_ray_data.yaml
@@ -1,0 +1,60 @@
+name: video-captioning-ray-data
+
+containerfile: ./Dockerfile
+
+# CoreWeave US-EAST-14A via Anyscale. RTX PRO 6000 (Blackwell, 96 GB) GPUs,
+# 8 per node. The Kueue queue label is required for scheduling on this cluster.
+compute_config:
+  cloud: rkn-gpu-cloud
+  cloud_resource: coreweave-use14a
+
+  advanced_instance_config:
+    metadata:
+      labels:
+        kueue.x-k8s.io/queue-name: default-queue
+
+  # Head node is control-plane only (no GPU) — GPUs live in the worker pool.
+  head_node:
+    required_resources:
+      CPU: 32
+      memory: 128Gi
+
+  worker_nodes:
+    # ── GPU pool: one Qwen3-VL-8B replica per RTX PRO 6000 (8 GPUs/node) ───
+    # SCALE LADDER — set min_nodes = max_nodes AND pass --env EXPECTED_GPUS:
+    #    8 GPUs (smoke) -> 1 node,   EXPECTED_GPUS=8
+    #   64 GPUs         -> 8 nodes,  EXPECTED_GPUS=64
+    #  256 GPUs         -> 32 nodes, EXPECTED_GPUS=256
+    - required_resources:
+        CPU: 120
+        memory: 960Gi
+        GPU: 8
+      required_labels:
+        ray.io/accelerator-type: RTX-PRO-6000
+      advanced_instance_config:
+        metadata:
+          labels:
+            kueue.x-k8s.io/queue-name: default-queue
+      min_nodes: 1
+      max_nodes: 1
+
+    # ── CPU-only pool: mp4 read + decode/keyframe stage ────────────────────
+    # Pinned via the cpu_only label so multi-MB blobs never share RAM with vLLM.
+    - required_resources:
+        CPU: 120
+        memory: 480Gi
+      labels:
+        cpu_only: "true"
+      advanced_instance_config:
+        metadata:
+          labels:
+            kueue.x-k8s.io/queue-name: default-queue
+      min_nodes: 1
+      max_nodes: 8
+
+working_dir: .
+
+entrypoint: python caption_ray_data.py ${NUM_VIDEOS:+--num-videos ${NUM_VIDEOS}} ${INPUT:+--input ${INPUT}} ${OUTPUT:+--output ${OUTPUT}}
+
+max_retries: 2
+timeout_s: 86400

--- a/video_captioning/utils.py
+++ b/video_captioning/utils.py
@@ -1,0 +1,418 @@
+"""Shared pieces for the video captioning example.
+
+Both pipelines import from this module so the *work* is identical and only the
+*orchestration* differs:
+
+  - caption_ray_core.py — hand-rolled Ray Core (tasks + actors + a manual loop)
+  - caption_ray_data.py — Ray Data + the native vLLM batch integration
+
+The pipeline has exactly two compute-heavy stages:
+
+    mp4 bytes ──► decode_and_sample()  (CPU: decord open, uniform frame sample)
+              ──► Qwen3-VL caption      (GPU: vLLM, one replica per GPU)
+
+This module holds those stages plus the small amount of cluster plumbing both
+scripts share: filesystem resolution, GPU wait, a per-node utilization sampler,
+and the throughput report.
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from io import BytesIO
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import ray
+from PIL import Image
+
+logger = logging.getLogger("video_captioning")
+
+# ---------------------------------------------------------------------------
+# Model + workload knobs (env-overridable so the job YAMLs can tune without
+# code edits).
+# ---------------------------------------------------------------------------
+
+# Qwen3-VL-8B matches much larger VLMs on video benchmarks while fitting one
+# replica per GPU (no tensor parallelism) — the throughput sweet spot.
+MODEL_SOURCE = os.environ.get("CAPTION_MODEL", "Qwen/Qwen3-VL-8B-Instruct")
+
+# Frames sampled per video, fed to the VLM as an ordered image sequence.
+NUM_KEYFRAMES = int(os.environ.get("NUM_KEYFRAMES", "6"))
+# Square resize before JPEG encode: bounds vision-token count and decode cost.
+IMAGE_SIZE = (int(os.environ.get("FRAME_SIZE", "448")),) * 2
+JPEG_QUALITY = int(os.environ.get("JPEG_QUALITY", "85"))
+
+MAX_MODEL_LEN = int(os.environ.get("MAX_MODEL_LEN", "8192"))
+CAPTION_MAX_TOKENS = int(os.environ.get("CAPTION_MAX_TOKENS", "256"))
+CAPTION_TEMPERATURE = float(os.environ.get("CAPTION_TEMPERATURE", "0.2"))
+
+# Dispatch batch size per caption request (vLLM continuous-batches internally).
+VLM_BATCH_SIZE = int(os.environ.get("VLM_BATCH_SIZE", "32"))
+
+SYSTEM_PROMPT = (
+    "You are a video captioning assistant. You are shown an ordered sequence of "
+    "frames sampled uniformly from a single video clip. Describe what happens "
+    "across the clip in one to three sentences: the setting, the main subjects, "
+    "and any action or change over time. Reply with the caption only — no "
+    "preamble, no markdown."
+)
+
+# Schema of the output parquet, shared by both pipelines.
+OUTPUT_COLUMNS = [
+    "video_id",
+    "duration_sec",
+    "fps",
+    "width",
+    "height",
+    "num_keyframes",
+    "caption",
+]
+
+
+def _user_prompt(num_frames: int) -> str:
+    return (
+        f"These {num_frames} frames are in temporal order from one video clip. "
+        "Write a single concise caption describing the whole clip."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 (CPU): decode + uniform keyframe sample
+# ---------------------------------------------------------------------------
+
+
+def _encode_jpeg(frame_rgb: np.ndarray) -> bytes:
+    img = Image.fromarray(frame_rgb).convert("RGB").resize(IMAGE_SIZE, Image.Resampling.BICUBIC)
+    buf = BytesIO()
+    img.save(buf, format="JPEG", quality=JPEG_QUALITY)
+    return buf.getvalue()
+
+
+def decode_and_sample(
+    video_bytes: bytes, video_id: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """Open one mp4 with decord, sample NUM_KEYFRAMES evenly, JPEG-encode them.
+
+    Returns a dict with keyframe bytes + lightweight metadata, or None if the
+    clip is undecodable / empty. The raw mp4 blob is never carried downstream.
+    """
+    from decord import VideoReader, cpu as decord_cpu
+
+    if not video_bytes:
+        return None
+    vid = video_id or hashlib.sha1(video_bytes[:4096]).hexdigest()[:12]
+    try:
+        vr = VideoReader(BytesIO(video_bytes), ctx=decord_cpu(0))
+        total_frames = len(vr)
+        fps = float(vr.get_avg_fps() or 30.0)
+        if total_frames == 0 or fps <= 0:
+            return None
+
+        n = min(NUM_KEYFRAMES, total_frames)
+        indices = np.linspace(0, total_frames - 1, n).astype(int).tolist()
+        frames = vr.get_batch(indices).asnumpy()
+        return {
+            "video_id": vid,
+            "duration_sec": round(total_frames / fps, 3),
+            "fps": round(fps, 3),
+            "width": int(frames[0].shape[1]),
+            "height": int(frames[0].shape[0]),
+            "num_keyframes": n,
+            "keyframes": [_encode_jpeg(f) for f in frames],
+        }
+    except Exception:
+        logger.exception("decode_and_sample failed for video_id=%s", vid)
+        return None
+
+
+def decode_row(row: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Ray Data flat_map adapter: {mp4: bytes} -> 0 or 1 decoded rows.
+
+    flat_map (not map) so undecodable clips are dropped instead of failing the
+    block. The mp4 column is projected out — only keyframes + metadata flow on.
+    """
+    decoded = decode_and_sample(row.get("mp4"), row.get("video_id"))
+    return [decoded] if decoded is not None else []
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 (GPU): VLM prompt construction + response parsing
+#
+# Two message builders because the two engines take images differently:
+#   - build_messages_pil -> Ray Data's ray.data.llm path wants PIL objects
+#   - build_messages_b64 -> raw vLLM `llm.chat` wants image_url data URIs
+# Both emit the same ordered-frame prompt, so captions are comparable.
+# ---------------------------------------------------------------------------
+
+
+def build_messages_pil(keyframes: List[bytes]) -> List[Dict[str, Any]]:
+    content: List[Dict[str, Any]] = [{"type": "text", "text": _user_prompt(len(keyframes))}]
+    for kf in keyframes:
+        content.append({"type": "image", "image": Image.open(BytesIO(kf))})
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": content},
+    ]
+
+
+def build_messages_b64(keyframes: List[bytes]) -> List[Dict[str, Any]]:
+    content: List[Dict[str, Any]] = [{"type": "text", "text": _user_prompt(len(keyframes))}]
+    for kf in keyframes:
+        uri = "data:image/jpeg;base64," + base64.b64encode(kf).decode("ascii")
+        content.append({"type": "image_url", "image_url": {"url": uri}})
+    return [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": content},
+    ]
+
+
+def sampling_params() -> Dict[str, Any]:
+    return {"temperature": CAPTION_TEMPERATURE, "max_tokens": CAPTION_MAX_TOKENS}
+
+
+def clean_caption(text: str) -> str:
+    """Normalize a raw VLM response into a single-line caption."""
+    if not text:
+        return ""
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+    return " ".join(text.split())
+
+
+# Ray Data pre/post adapters for ray.data.llm (used by caption_ray_data.py).
+
+_PASSTHROUGH_COLS = [c for c in OUTPUT_COLUMNS if c != "caption"]
+
+
+def vlm_preprocess(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Decoded row -> chat-completion request + passthrough metadata columns."""
+    result: Dict[str, Any] = {
+        "messages": build_messages_pil(list(row["keyframes"])),
+        "sampling_params": sampling_params(),
+    }
+    for col in _PASSTHROUGH_COLS:
+        result[col] = row[col]
+    return result
+
+
+def vlm_postprocess(row: Dict[str, Any]) -> Dict[str, Any]:
+    """vLLM response -> output row: metadata + the cleaned caption."""
+    result = {col: row[col] for col in _PASSTHROUGH_COLS}
+    result["caption"] = clean_caption(row.get("generated_text", ""))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Cluster plumbing shared by both pipelines
+# ---------------------------------------------------------------------------
+
+
+def worker_setup():
+    """Per-worker startup hook (worker_process_setup_hook / actor init).
+
+    Spreads each process's VLLM_PORT probe base so simultaneous engine starts
+    on one node don't race to the same torch.distributed rendezvous port — at
+    8 engines/node starting in the same second, two engines can otherwise grab
+    the same port and die with EADDRINUSE. setdefault so an explicit VLLM_PORT
+    env wins.
+    """
+    os.environ.setdefault("VLLM_PORT", str(30000 + (os.getpid() * 211) % 20000))
+
+
+def filesystem_and_path(uri: str) -> Tuple[Any, str]:
+    """Resolve a URI to (pyarrow filesystem, filesystem-relative path).
+
+    Clusters that point S3 clients at a custom endpoint (AWS_ENDPOINT_URL_S3 —
+    e.g. CoreWeave object storage) need the filesystem built explicitly: those
+    endpoints require virtual-hosted addressing, which pyarrow's default
+    path-style requests don't use.
+    """
+    import pyarrow.fs as pafs
+
+    endpoint = os.environ.get("AWS_ENDPOINT_URL_S3")
+    if uri.startswith("s3://") and endpoint:
+        scheme, host = endpoint.split("://", 1)
+        fs = pafs.S3FileSystem(
+            endpoint_override=host,
+            scheme=scheme,
+            force_virtual_addressing=True,
+            region=os.environ.get("AWS_REGION", "us-east-1"),
+        )
+        return fs, uri.split("://", 1)[-1]
+    return pafs.FileSystem.from_uri(uri)
+
+
+def default_output(pipeline: str) -> str:
+    """A unique output prefix for one run, preferring the cloud's object storage
+    (ANYSCALE_ARTIFACT_STORAGE is a cluster-wide s3://... prefix with credentials
+    already wired). Falls back to node-local /tmp outside Anyscale."""
+    base = os.environ.get("ANYSCALE_ARTIFACT_STORAGE", "/tmp").rstrip("/")
+    return f"{base}/video_captioning/{pipeline}/{time.strftime('%Y%m%d-%H%M%S')}"
+
+
+def wait_for_gpus(min_gpus: int, timeout_s: int = 1800) -> int:
+    """Block until at least `min_gpus` GPUs have joined the Ray cluster.
+
+    GPU worker nodes provision after the driver starts, so reading
+    `ray.cluster_resources()` immediately would report 0 GPUs. Poll until the
+    pool is up (or timeout), then return the GPU count actually seen.
+    """
+    deadline = time.time() + timeout_s
+    seen = 0
+    while time.time() < deadline:
+        seen = int(ray.cluster_resources().get("GPU", 0))
+        if seen >= min_gpus:
+            return seen
+        logger.info("Waiting for GPUs to join the cluster (have %d, want %d)...", seen, min_gpus)
+        time.sleep(5)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Utilization sampling + throughput report
+# ---------------------------------------------------------------------------
+
+
+@ray.remote(num_cpus=0)
+class _NodeSampler:
+    """Samples GPU utilization (NVML) and CPU utilization (psutil) on one node
+    on a fixed interval until result() is called."""
+
+    def __init__(self, interval_s: float):
+        self.gpu: List[float] = []
+        self.cpu: List[float] = []
+        self._stop = threading.Event()
+        try:
+            import pynvml
+
+            pynvml.nvmlInit()
+            self._nvml, self._n_gpu = pynvml, pynvml.nvmlDeviceGetCount()
+        except Exception:
+            self._nvml, self._n_gpu = None, 0
+        import psutil
+
+        self._psutil = psutil
+        psutil.cpu_percent(interval=None)  # prime the counter
+        threading.Thread(target=self._loop, args=(interval_s,), daemon=True).start()
+
+    def _loop(self, interval_s: float):
+        while not self._stop.wait(interval_s):
+            if self._nvml is not None:
+                per_gpu = []
+                for i in range(self._n_gpu):
+                    try:
+                        handle = self._nvml.nvmlDeviceGetHandleByIndex(i)
+                        per_gpu.append(float(self._nvml.nvmlDeviceGetUtilizationRates(handle).gpu))
+                    except Exception:
+                        pass
+                if per_gpu:
+                    self.gpu.append(sum(per_gpu) / len(per_gpu))
+            self.cpu.append(float(self._psutil.cpu_percent(interval=None)))
+
+    def result(self) -> Dict[str, List[float]]:
+        self._stop.set()
+        return {"gpu": self.gpu, "cpu": self.cpu}
+
+
+def _summary(samples: List[float]) -> Dict[str, float]:
+    if not samples:
+        return {"mean": 0.0, "p95": 0.0, "n": 0}
+    s = sorted(samples)
+    return {
+        "mean": round(sum(s) / len(s), 1),
+        "p95": round(s[min(len(s) - 1, int(0.95 * len(s)))], 1),
+        "n": len(s),
+    }
+
+
+class UtilizationMonitor:
+    """Pins one _NodeSampler to every worker node; stop() returns cluster-wide
+    GPU/CPU utilization (mean/p95). This answers the balance question the
+    example poses: are the engines busy, and is decode keeping them fed?"""
+
+    def __init__(self, interval_s: float = 5.0):
+        self.interval_s = interval_s
+        self._samplers: List[Any] = []
+
+    def start(self) -> "UtilizationMonitor":
+        from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+        head = ray.get_runtime_context().get_node_id()
+        for node in ray.nodes():
+            if not node.get("Alive") or node["NodeID"] == head:
+                continue  # the head node is control-plane only
+            strategy = NodeAffinitySchedulingStrategy(node_id=node["NodeID"], soft=False)
+            self._samplers.append(
+                _NodeSampler.options(scheduling_strategy=strategy).remote(self.interval_s)
+            )
+        return self
+
+    def stop(self) -> Dict[str, Any]:
+        refs = [s.result.remote() for s in self._samplers]
+        # Bounded wait: a sampler on a node that scaled down would hang forever.
+        ready, _ = ray.wait(refs, num_returns=len(refs), timeout=60) if refs else ([], [])
+        gpu, cpu = [], []
+        for ref in ready:
+            try:
+                res = ray.get(ref)
+                gpu += res["gpu"]
+                cpu += res["cpu"]
+            except Exception:
+                pass
+        return {"gpu_util": _summary(gpu), "cpu_util": _summary(cpu)}
+
+
+def write_report(
+    pipeline: str,
+    num_gpus: int,
+    num_captions: int,
+    video_seconds: float,
+    wall_seconds: float,
+    utilization: Dict[str, Any],
+    output_uri: str,
+):
+    """Log the headline numbers and write report.json next to the captions."""
+    wall = max(wall_seconds, 1e-9)
+    report = {
+        "pipeline": pipeline,
+        "model": MODEL_SOURCE,
+        "num_gpus": num_gpus,
+        "num_captions": num_captions,
+        "wall_seconds": round(wall_seconds, 1),
+        "captions_per_sec": round(num_captions / wall, 3),
+        "captions_per_gpu_per_sec": round(num_captions / wall / max(num_gpus, 1), 4),
+        "video_hours_per_wall_hour": round(video_seconds / wall, 2),
+        "utilization": utilization,
+    }
+    logger.info("=" * 62)
+    logger.info("THROUGHPUT REPORT  (%s, %d GPUs)", pipeline, num_gpus)
+    logger.info("=" * 62)
+    logger.info("  captions generated      : %d", num_captions)
+    logger.info("  wall time               : %.1f s", wall_seconds)
+    logger.info("  captions/sec            : %s", report["captions_per_sec"])
+    logger.info("  captions/GPU/sec        : %s", report["captions_per_gpu_per_sec"])
+    logger.info("  video-hours / wall-hour : %s", report["video_hours_per_wall_hour"])
+    logger.info("  GPU util mean/p95       : %s / %s",
+                utilization["gpu_util"]["mean"], utilization["gpu_util"]["p95"])
+    logger.info("  CPU util mean/p95       : %s / %s",
+                utilization["cpu_util"]["mean"], utilization["cpu_util"]["p95"])
+    logger.info("=" * 62)
+    # Also print(): `anyscale job logs` shows driver stdout, not the log stream.
+    print("THROUGHPUT_REPORT " + json.dumps(report), flush=True)
+
+    body = json.dumps(report, indent=2).encode()
+    if "://" in output_uri:
+        fs, path = filesystem_and_path(output_uri)
+        with fs.open_output_stream(f"{path}/report.json") as f:
+            f.write(body)
+    else:
+        os.makedirs(output_uri, exist_ok=True)
+        with open(os.path.join(output_uri, "report.json"), "wb") as f:
+            f.write(body)
+    logger.info("Wrote report.json to %s", output_uri)


### PR DESCRIPTION
## What

Adds `video_captioning/`: captions the [FineVideo](https://huggingface.co/datasets/HuggingFaceFV/finevideo) corpus with [Qwen3-VL-8B](https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct) served by vLLM (one replica per GPU), implemented **twice** on identical hardware so throughput, GPU/CPU utilization, and code complexity can be compared directly:

- `caption_ray_core.py` — the baseline, hand-built on Ray Core: shard-reader/decode tasks, a pool of GPU caption actors, and a manual scheduling loop with hand-rolled backpressure, batching, round-robin dispatch, and partial-batch draining (and no fault tolerance).
- `caption_ray_data.py` — the same DAG on Ray Data with the native `ray.data.llm` vLLM integration: streaming, backpressure, and fault tolerance come from the framework.
- `utils.py` — the shared *work* (decord decode + uniform keyframe sampling, Qwen3-VL prompt construction, utilization sampling, throughput report), so any performance difference comes from orchestration alone.

Both jobs write captions as parquet plus a `report.json` with captions/sec, captions/GPU/sec, video-hours per wall-hour, and NVML/psutil utilization summaries.

## How to run

```bash
export HF_TOKEN=hf_...   # FineVideo is gated

anyscale job submit -f job_ray_data.yaml --env HF_TOKEN=$HF_TOKEN --env NUM_VIDEOS=500
anyscale job submit -f job_ray_core.yaml --env HF_TOKEN=$HF_TOKEN --env NUM_VIDEOS=500
```

The committed YAMLs default to an 8-GPU smoke test (RTX PRO 6000, one node); scale by raising the GPU pool's `min_nodes`/`max_nodes` and `EXPECTED_GPUS`.

## Root README

Adds the example to the Curate stage table, the "Pretraining data factory" journey, and the vLLM acknowledgments row.